### PR TITLE
Delete unused vercel.json

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,7 +1,0 @@
-{
-  "functions": {
-    "api/canvas.js": {
-      "includeFiles": "api/assets/**"
-    }
-  }
-}


### PR DESCRIPTION
These files should automatically be included since `path.join()` is used in `api/canvas.js`